### PR TITLE
Package name is not valid. #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://salamanderbe.github.io/vue-tour
 ## Install & basic usage
 
 ```bash
-npm install @salamander.be/vue-tour
+npm install "@salamander.be/vue-tour"
 ```
 
 ```vue


### PR DESCRIPTION
Package name is not valid. #29.
https://github.com/salamanderbe/vue-tour/issues/29#issue-1377842497
The package was not installing with default npm command, there is a typo mistake,
we have to simply add double quotes around package name and this is. our issue has been solved!